### PR TITLE
Fix 3D viewer sizing and initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,9 +26,9 @@ window.addEventListener('DOMContentLoaded', () => {
   }, { threshold: 0.4 });
 
   counters.forEach(c => io.observe(c));
-
-  initThree();
 });
+
+window.addEventListener('load', initThree);
 
 function animateCounter(el) {
   const target = +el.dataset.target;

--- a/style.css
+++ b/style.css
@@ -162,6 +162,8 @@ img {
     min-height: 300px;
     position: absolute;
     inset: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .pub-3d canvas {


### PR DESCRIPTION
## Summary
- ensure `.pub-3d` always has a measurable size
- initialise the Three.js scene after window load

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684464c00f1c832cb2957fdd80ba054a