### PR TITLE
Set package type to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-portfolio-website",
   "version": "1.0.0",
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- change the package type to CommonJS so Jest treats .js files as CommonJS modules

## Testing
- npm test *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cc28537930832c935deb869672d83a