### PR TITLE
Improve mobile navigation accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,10 @@
   <header>
     <nav class="navbar">
       <div class="logo">Varad Karkhanis</div>
-      <div class="menu-toggle"><i class="fas fa-bars"></i></div>
-      <ul class="nav-links">
+      <button type="button" class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation" aria-label="Toggle navigation">
+        <i class="fas fa-bars" aria-hidden="true"></i>
+      </button>
+      <ul class="nav-links" id="primary-navigation">
         <li><a href="#about">About</a></li>
         <li><a href="#projects">Projects</a></li>
         <li><a href="#resume">Resume</a></li>

--- a/script.js
+++ b/script.js
@@ -15,9 +15,21 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const menuToggle = document.querySelector('.menu-toggle');
   const navLinks = document.querySelector('.nav-links');
-  menuToggle.addEventListener('click', () => {
-    navLinks.classList.toggle('show');
-  });
+
+  if (menuToggle && navLinks) {
+    menuToggle.addEventListener('click', () => {
+      const isOpen = navLinks.classList.toggle('show');
+      menuToggle.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    navLinks.addEventListener('click', event => {
+      const link = event.target.closest('a');
+      if (link && navLinks.classList.contains('show')) {
+        navLinks.classList.remove('show');
+        menuToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
 
   const counters = document.querySelectorAll('.pub-number');
   const io = new IntersectionObserver(entries => {

--- a/style.css
+++ b/style.css
@@ -43,6 +43,11 @@ img {
     display: none;
     font-size: 1.5rem;
     cursor: pointer;
+    background: none;
+    border: 0;
+    color: inherit;
+    padding: 0;
+    line-height: 1;
 }
 
 .hero {
@@ -288,7 +293,9 @@ footer {
     }
 
     .menu-toggle {
-        display: block;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
 
     .about-container {


### PR DESCRIPTION
## Summary
- swap the mobile navigation toggle to a semantic button with ARIA wiring and label the controlled menu
- restyle the toggle so it keeps the icon appearance without the default button chrome
- update the script to sync the button’s aria-expanded state and close the menu after a link is chosen

## Testing
- npm install *(fails: 403 Forbidden fetching jest)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2854a3d4832cb2edf5957164bd00