### PR TITLE
Guard nav menu toggle registration when markup missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,9 +16,11 @@ if (typeof window !== 'undefined') {
 
     const menuToggle = document.querySelector('.menu-toggle');
     const navLinks = document.querySelector('.nav-links');
-    menuToggle.addEventListener('click', () => {
-      navLinks.classList.toggle('show');
-    });
+    if (menuToggle && navLinks) {
+      menuToggle.addEventListener('click', () => {
+        navLinks.classList.toggle('show');
+      });
+    }
 
     const counters = document.querySelectorAll('.pub-number');
     if (!('IntersectionObserver' in window)) {


### PR DESCRIPTION
## Summary
- add a null check for the navigation toggle elements before attaching the click handler so the script can run without the nav markup
- preserve the rest of the DOMContentLoaded initialization so counters and animations continue functioning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2e0f52bc832c9ece40f4d53c051a